### PR TITLE
Add envs command

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ This command uninstalls the extensions and deletes the `.extensions.lock` file.
 $ rex
 Commands:
   rex help [COMMAND]  # Describe available commands or one specific command
+  dev envs            # Show the list of defined environments in .extensions.rb
   rex install [ENV]   # Install extensions for the specified environment
   rex state           # Show the current state of the installed extensions
   rex switch [ENV]    # Uninstall extensions for the currently installed environment and install extensions for the specified environment

--- a/lib/rexer/cli.rb
+++ b/lib/rexer/cli.rb
@@ -31,6 +31,11 @@ module Rexer
       Commands::State.new.call
     end
 
+    desc "envs", "Show the list of defined environments in .extensions.rb"
+    def envs
+      Commands::Envs.new.call
+    end
+
     desc "version", "Show Rexer version"
     def version
       puts Rexer::VERSION

--- a/lib/rexer/commands/envs.rb
+++ b/lib/rexer/commands/envs.rb
@@ -1,0 +1,24 @@
+module Rexer
+  module Commands
+    class Envs
+      def initialize
+        @definition = Definition.load_data
+      end
+
+      def call
+        defined_envs.each do
+          puts _1
+        end
+      end
+
+      private
+
+      attr_reader :definition
+
+      def defined_envs
+        all_envs = definition.plugins.map(&:env) + definition.themes.map(&:env)
+        all_envs.uniq
+      end
+    end
+  end
+end

--- a/test/integration/integration_test.rb
+++ b/test/integration/integration_test.rb
@@ -11,7 +11,7 @@ class IntegrationTest < Test::Unit::TestCase
     docker_stop
   end
 
-  test "rex version, install, uninstall and state" do
+  test "rex version, install, uninstall, state and envs" do
     result = docker_exec("rex version")
     assert_equal Rexer::VERSION, result.output_str
 
@@ -23,6 +23,11 @@ class IntegrationTest < Test::Unit::TestCase
     docker_exec("rex uninstall").then do |result|
       assert_true result.success?
       assert_equal "No lock file found", result.output_str
+    end
+
+    docker_exec("rex envs").then do |result|
+      assert_true result.success?
+      assert_equal %w[default env1 env2 env3], result.output
     end
 
     docker_exec("rex install").then do |result|


### PR DESCRIPTION
This PR add a new command `envs`. This command shows the list of defined environments in `.extensions.rb`.

```ruby
plugin :hello_world_plugin, github: { repo: "hello/world_plugin" }

env :stable do
  plugin :hello_world_plugin, github: { repo: "hello/world_plugin" , branch: "stable" }
end

env :staging do
  plugin :hello_world_plugin, github: { repo: "hello/world_plugin" , branch: "staging" }  
end
```

If there is `.extensions.rb` with above definition, executing `rex envs` command will output the following:

```
$ rex envs
default
stable
staging
```