### PR TITLE
Revert "Configuration for the command prefix"

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,18 +120,6 @@ plugin :redmica_s3, github: { repo: "redmica/redmica_s3" } do
 end
 ```
 
-## Configuring the command prefix
-
-You can configure the command prefix for the commands that Rexer runs such as `bundle install` and `bin/rails redmine:plugins:migrate`.
-
-```ruby
-config command_prefix: "docker compose exec -T app"
-
-plugin :some_plugin_with_db_migration, github: { repo: "some_plugin" }
-```
-
-In the above example, the `bin/rails redmine:plugins:migrate` command is executed as `docker compose exec -T app bin/rails redmine:plugins:migrate`.
-
 ## Developing
 
 ### Running tests

--- a/lib/rexer/commands/install.rb
+++ b/lib/rexer/commands/install.rb
@@ -17,7 +17,7 @@ module Rexer
       private
 
       def install_initially(definition)
-        install(definition.themes, definition.plugins, definition.config)
+        install(definition.themes, definition.plugins)
 
         create_lock_file(definition.env)
         print_state
@@ -26,8 +26,8 @@ module Rexer
       def apply_diff(lock_definition, definition)
         diff = lock_definition.diff(definition)
 
-        install(diff.added_themes, diff.added_plugins, definition.config)
-        uninstall(diff.deleted_themes, diff.deleted_plugins, definition.config)
+        install(diff.added_themes, diff.added_plugins)
+        uninstall(diff.deleted_themes, diff.deleted_plugins)
         reload_source(diff.source_changed_themes, diff.source_changed_plugins)
 
         create_lock_file(definition.env)
@@ -44,23 +44,23 @@ module Rexer
         Definition::Lock.load_data if Definition::Lock.file.exist?
       end
 
-      def install(themes, plugins, config)
+      def install(themes, plugins)
         themes.each do
           Extension::Theme::Installer.new(_1).install
         end
 
         plugins.each do
-          Extension::Plugin::Installer.new(_1, config).install
+          Extension::Plugin::Installer.new(_1).install
         end
       end
 
-      def uninstall(themes, plugins, config)
+      def uninstall(themes, plugins)
         themes.each do
           Extension::Theme::Uninstaller.new(_1).uninstall
         end
 
         plugins.each do
-          Extension::Plugin::Uninstaller.new(_1, config).uninstall
+          Extension::Plugin::Uninstaller.new(_1).uninstall
         end
       end
 

--- a/lib/rexer/definition.rb
+++ b/lib/rexer/definition.rb
@@ -10,17 +10,6 @@ module Rexer
       end
     end
 
-    Config = ::Data.define(
-      # The prefix of the command such as bundle install and bin/rails redmine:plugins:migrate.
-      #
-      # For example, if the command_prefix is set "docker compose exec -T app",
-      # then bundle install will be executed as follows:
-      #
-      #   docker compose exec -T app bundle install
-      #
-      :command_prefix
-    )
-
     Source = ::Data.define(:type, :options)
 
     Plugin = ::Data.define(:name, :source, :hooks, :env) do

--- a/lib/rexer/definition/data.rb
+++ b/lib/rexer/definition/data.rb
@@ -2,12 +2,11 @@ module Rexer
   module Definition
     class Data
       attr_accessor :env
-      attr_reader :config, :version
+      attr_reader :version
 
-      def initialize(plugins, themes, config, env: nil, version: nil)
+      def initialize(plugins, themes, env: nil, version: nil)
         @plugins = plugins
         @themes = themes
-        @config = config
         @env = env
         @version = version
       end

--- a/lib/rexer/definition/dsl.rb
+++ b/lib/rexer/definition/dsl.rb
@@ -5,7 +5,6 @@ module Rexer
         @plugins = []
         @themes = []
         @env = env
-        @config = nil
       end
 
       def plugin(name, **opts, &hooks)
@@ -33,12 +32,8 @@ module Rexer
         @themes += data.themes
       end
 
-      def config(command_prefix: nil)
-        @config = Definition::Config.new(command_prefix)
-      end
-
       def to_data
-        Definition::Data.new(@plugins, @themes, @config)
+        Definition::Data.new(@plugins, @themes)
       end
 
       private

--- a/lib/rexer/definition/lock.rb
+++ b/lib/rexer/definition/lock.rb
@@ -27,7 +27,7 @@ module Rexer
         end
 
         def to_data
-          Definition::Data.new(@plugins, @themes, @config, **lock_state)
+          Definition::Data.new(@plugins, @themes, **lock_state)
         end
 
         private

--- a/lib/rexer/extension/plugin.rb
+++ b/lib/rexer/extension/plugin.rb
@@ -8,16 +8,15 @@ module Rexer
       end
 
       class Base
-        def initialize(definition, config = nil)
+        def initialize(definition)
           @definition = definition
           @name = definition.name
           @hooks = definition.hooks || {}
-          @config = config
         end
 
         private
 
-        attr_reader :name, :hooks, :definition, :config
+        attr_reader :name, :hooks, :definition
 
         def plugin_dir
           @plugin_dir ||= Plugin.dir.join(name.to_s)
@@ -37,17 +36,13 @@ module Rexer
           return unless needs_db_migration?
 
           envs = {"NAME" => name.to_s}.merge(extra_envs)
-          _, error, status = Open3.capture3(envs, cmd_with_prefix("bin/rails redmine:plugins:migrate"))
+          _, error, status = Open3.capture3(envs, "bin/rails redmine:plugins:migrate")
 
           raise error unless status.success?
         end
 
         def source
           @source ||= Source.from_definition(definition.source)
-        end
-
-        def cmd_with_prefix(command)
-          [config&.command_prefix, command].compact.join(" ")
         end
       end
 
@@ -70,7 +65,7 @@ module Rexer
         def run_bundle_install
           return unless plugin_dir.join("Gemfile").exist?
 
-          _, error, status = Open3.capture3(cmd_with_prefix("bundle install"))
+          _, error, status = Open3.capture3("bundle install")
           raise error unless status.success?
         end
       end

--- a/test/integration/integration_helper.rb
+++ b/test/integration/integration_helper.rb
@@ -23,9 +23,9 @@ module IntegrationHelper
 
   def container_name = "rexer-test-container"
 
-  def run_with_capture(command, raise_on_error: false)
+  def run_with_capture(command, raise: false)
     Result.new(*Open3.capture3(command)) do |result|
-      raise result.error if raise_on_error && !result.success?
+      raise result.error if raise && !result.success?
     end
   end
 
@@ -36,11 +36,11 @@ module IntegrationHelper
   end
 
   def setup_rexer
-    docker_exec("/setup_rexer.sh", raise_on_error: true)
+    docker_exec("/setup_rexer.sh", raise: true)
   end
 
   def docker_build
-    image_exists = run_with_capture("docker inspect #{image_name}", raise_on_error: true).success?
+    image_exists = run_with_capture("docker inspect #{image_name}", raise: true).success?
 
     system "rake rexer:test:build_integration_test_image", exception: true unless image_exists
   end
@@ -48,7 +48,7 @@ module IntegrationHelper
   def docker_launch
     run_with_capture(
       "docker run --rm -d -v rexer-redmine-bundle-cache:/redmine/vendor/cache -v $PWD:/rexer-src --name #{container_name} #{image_name}",
-      raise_on_error: true
+      raise: true
     )
 
     try = 0
@@ -59,12 +59,12 @@ module IntegrationHelper
     end
   end
 
-  def docker_exec(*command, raise_on_error: false)
-    run_with_capture("docker exec #{container_name} #{command.join(" && ")}", raise_on_error:)
+  def docker_exec(*command, raise: false)
+    run_with_capture("docker exec #{container_name} #{command.join(" && ")}", raise:)
   end
 
   def docker_stop
-    run_with_capture("docker container stop -t 0 #{container_name} && docker container rm #{container_name}", raise_on_error: true)
+    run_with_capture("docker container stop -t 0 #{container_name} && docker container rm #{container_name}", raise: true)
   end
 
   def legacy_theme_dir?


### PR DESCRIPTION
Reverts hidakatsuya/rexer#9

I reconsidered the command prefix should not be defined in `.extensions.rb`. I will revert this feature and implement with other method.