### PR TITLE
Enable ERB by default

### DIFF
--- a/lib/rexer/cli.rb
+++ b/lib/rexer/cli.rb
@@ -1,5 +1,6 @@
 require "thor"
 require "dotenv"
+require "erb"
 
 module Rexer
   class Cli < Thor

--- a/test/integration/docker/extensions.rb
+++ b/test/integration/docker/extensions.rb
@@ -13,7 +13,7 @@ end
 env :env3 do
   plugin :plugin_a, git: {url: "/git-server-repos/plugin_a.git", branch: "stable"} do
     installed do
-      puts "plugin_a installed"
+      puts ERB.new("<%= 'plugin_a installed' %>").result
     end
 
     uninstalled do


### PR DESCRIPTION
```ruby
# .extensions.rb

plugin :plugin_foo, github: { repo: "plugin/foo" } do
  installed do
    Pathname.new("config/foo.yml").write(ERB.new(<<~YAML).result)
      access_key_id: <%= ENV["KEY_ID"] %>
    YAML
  end
end
```