### PR TITLE
Output the results of extensions whose process was skipped

### DIFF
--- a/lib/rexer/commands.rb
+++ b/lib/rexer/commands.rb
@@ -36,6 +36,10 @@ module Rexer
         Rexer.verbosity.on(:info) { puts Paint["done", :green] }
       end
 
+      def skipped(reason)
+        Rexer.verbosity.on(:info) { puts Paint["skipped (#{reason})", :yellow] }
+      end
+
       def processing(process_title)
         Rexer.verbosity.on(:debug) { puts Paint[process_title, :gray] }
       end

--- a/lib/rexer/extension/plugin.rb
+++ b/lib/rexer/extension/plugin.rb
@@ -62,9 +62,12 @@ module Rexer
 
       class Install < Base
         def call
-          return if plugin_exists?
-
           broadcast(:started, "Install #{name}")
+
+          if plugin_exists?
+            broadcast(:skipped, "Already exists")
+            return
+          end
 
           load_from_source
           run_bundle_install
@@ -93,9 +96,12 @@ module Rexer
 
       class Uninstall < Base
         def call
-          return unless plugin_exists?
-
           broadcast(:started, "Uninstall #{name}")
+
+          unless plugin_exists?
+            broadcast(:skipped, "Not exists")
+            return
+          end
 
           reset_db_migration
           remove_plugin
@@ -120,6 +126,11 @@ module Rexer
           return unless plugin_exists?
 
           broadcast(:started, "Update #{name}")
+
+          unless source.updatable?
+            broadcast(:skipped, "Not updatable")
+            return
+          end
 
           update_source
           run_db_migrate

--- a/lib/rexer/extension/theme.rb
+++ b/lib/rexer/extension/theme.rb
@@ -42,9 +42,12 @@ module Rexer
 
       class Install < Base
         def call
-          return if theme_exists?
-
           broadcast(:started, "Install #{name}")
+
+          if theme_exists?
+            broadcast(:skipped, "Already exists")
+            return
+          end
 
           load_from_source
           hooks[:installed]&.call
@@ -61,9 +64,12 @@ module Rexer
 
       class Uninstall < Base
         def call
-          return unless theme_exists?
-
           broadcast(:started, "Uninstall #{name}")
+
+          unless theme_exists?
+            broadcast(:skipped, "Not exists")
+            return
+          end
 
           remove_theme
           hooks[:uninstalled]&.call

--- a/lib/rexer/source/base.rb
+++ b/lib/rexer/source/base.rb
@@ -15,6 +15,12 @@ module Rexer
         raise "Not implemented"
       end
 
+      # Check if the source can be updated to a newer version.
+      def updatable?
+        raise "Not implemented"
+      end
+
+      # Return the status of the source.
       def info = ""
     end
   end

--- a/lib/rexer/source/git.rb
+++ b/lib/rexer/source/git.rb
@@ -19,6 +19,10 @@ module Rexer
         load(path)
       end
 
+      def updatable?
+        !branch.nil?
+      end
+
       def info
         branch || tag || ref || "master"
       end

--- a/test/integration/integration_test.rb
+++ b/test/integration/integration_test.rb
@@ -142,6 +142,15 @@ class IntegrationTest < Test::Unit::TestCase
       assert_includes result.output, "plugin_a uninstalled"
       assert_includes result.output, "theme_a uninstalled"
     end
+
+    docker_exec("rex install env1 -q").then do |result|
+      assert_true result.success?
+    end
+
+    docker_exec("rex update").then do |result|
+      assert_true result.success?
+      assert_includes result.output_str, "plugin_a ... #{Paint["skipped (Not updatable)", :yellow]}"
+    end
   end
 
   test "rex install with adding/removing other plugin and changing the source" do


### PR DESCRIPTION
Skip if the extension already exists.
```
$ rex install
Install bleuclair ... done
Install redmine_issues_panel ... skipped (Already exists)
Install view_customize ... done
```

Skip if the extension does not exist.
```
$ rex uninstall
Install bleuclair ... done
Install redmine_issues_panel ... skipped (Not exists)
Install view_customize ... done
```

Skip if source setting is `tag` or `ref`.
```
$ rex update
Update bleuclair ... done
Update redmine_issues_panel ... skipped (Not updateable)
Update view_customize ... skipped (Not updateable)
```
