### PR TITLE
Allow env dsl to take multiple env name arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,19 +117,21 @@ Loads `.extensions.lock` and updates the currently installed extensions to the l
 You can define an environment and extensions for each environment using the `env ... do - end` block.
 
 ```ruby
-theme :bleuclair, github: { repo: "farend/redmine_theme_farend_bleuclair" }
 plugin :redmine_issues_panel, git: { url: "https://github.com/redmica/redmine_issues_panel" }
 
 env :stable do
-  theme :bleuclair, github: { repo: "farend/redmine_theme_farend_bleuclair", branch: "support-propshaft" }
   plugin :redmine_issues_panel, git: { url: "https://github.com/redmica/redmine_issues_panel", tag: "v1.0.2" }
+end
+
+env :default, :stable do
+  theme :bleuclair, github: { repo: "farend/redmine_theme_farend_bleuclair", branch: "support-propshaft" }
 end
 ```
 
 Definitions other than `env ... do - end` are implicitly defined as `env :default do - end`. Therefore, the above is resolved as follows:
 
 * default env
-  * bleuclair (master)
+  * bleuclair (support-propshaft)
   * redmine_issues_panel (master)
 * stable env
   * bleuclair (support-propshaft)

--- a/lib/rexer/definition/dsl.rb
+++ b/lib/rexer/definition/dsl.rb
@@ -25,11 +25,13 @@ module Rexer
         )
       end
 
-      def env(env_name, &dsl)
-        data = self.class.new(env_name).tap { _1.instance_eval(&dsl) }.to_data
+      def env(*env_names, &dsl)
+        env_names.each do |env_name|
+          data = self.class.new(env_name).tap { _1.instance_eval(&dsl) }.to_data
 
-        @plugins += data.plugins
-        @themes += data.themes
+          @plugins += data.plugins
+          @themes += data.themes
+        end
       end
 
       def to_data

--- a/test/integration/docker/extensions.rb
+++ b/test/integration/docker/extensions.rb
@@ -1,5 +1,4 @@
 theme :theme_a, git: {url: "/git-server-repos/theme_a.git"}
-plugin :plugin_a, git: {url: "/git-server-repos/plugin_a.git"}
 
 env :env1 do
   plugin :plugin_a, git: {url: "/git-server-repos/plugin_a.git", tag: ENV["PLUGIN_A_LATEST_VERSION"]}
@@ -30,4 +29,8 @@ env :env3 do
       puts "theme_a uninstalled"
     end
   end
+end
+
+env :default, :env4 do
+  plugin :plugin_a, git: {url: "/git-server-repos/plugin_a.git"}
 end

--- a/test/integration/integration_helper.rb
+++ b/test/integration/integration_helper.rb
@@ -44,7 +44,7 @@ module IntegrationHelper
   def docker_build
     image_exists = run_with_capture("docker inspect #{image_name}", raise_on_error: true).success?
 
-    system "rake rexer:test:build_integration_test_image", exception: true unless image_exists
+    system "rake test:prepare_integration", exception: true unless image_exists
   end
 
   def docker_launch

--- a/test/integration/integration_test.rb
+++ b/test/integration/integration_test.rb
@@ -27,7 +27,7 @@ class IntegrationTest < Test::Unit::TestCase
 
     docker_exec("rex envs").then do |result|
       assert_true result.success?
-      assert_equal %w[default env1 env2 env3], result.output
+      assert_equal %w[default env1 env2 env3 env4].sort, result.output.sort
     end
 
     docker_exec("rex install -q").then do |result|
@@ -108,6 +108,17 @@ class IntegrationTest < Test::Unit::TestCase
         "",
         "Themes:",
         " * theme_a (master)",
+        "",
+        "Plugins:",
+        " * plugin_a (master)"
+      ], result.output
+    end
+
+    docker_exec("rex switch env4 -q").then do |result|
+      assert_true result.success?
+      assert_equal [
+        "Rexer: #{Rexer::VERSION}",
+        "Env: env4",
         "",
         "Plugins:",
         " * plugin_a (master)"


### PR DESCRIPTION
```ruby
# .extensions.rb

plugin :plugin_a, github: { repo: "plugin/a" }

env :default, :env2 do
  plugin :plugin_b, github: { repo: "plugin/b" }
end

env :env2 do
  plugin :plugin_c, github: { repo: "plugin/c" }
end
```

`:default` env contains `:plugin_a` and `:plugin_b`.
`:env2` env contains `:plugin_c` and `:plugin_b` .