### PR TITLE
Add list of plugins and themes to envs command output

### DIFF
--- a/lib/rexer/commands/envs.rb
+++ b/lib/rexer/commands/envs.rb
@@ -6,7 +6,17 @@ module Rexer
       end
 
       def call
-        puts(*defined_envs)
+        envs = defined_envs
+        envs.each.with_index do |env_name, i|
+          puts env_name
+
+          definition = definition_on(env_name)
+          definition.then { _1.themes + _1.plugins }.each do
+            puts "  #{_1.name} (#{Source.from_definition(_1.source).info})"
+          end
+
+          puts if i < envs.size - 1
+        end
       end
 
       private
@@ -16,6 +26,12 @@ module Rexer
       def defined_envs
         all_envs = definition.plugins.map(&:env) + definition.themes.map(&:env)
         all_envs.uniq.sort
+      end
+
+      def definition_on(env)
+        Definition.load_data.tap { |data|
+          data.env = env
+        }
       end
     end
   end

--- a/lib/rexer/commands/envs.rb
+++ b/lib/rexer/commands/envs.rb
@@ -6,16 +6,15 @@ module Rexer
       end
 
       def call
-        envs = defined_envs
-        envs.each.with_index do |env_name, i|
-          puts env_name
+        defined_envs = definition.envs
+        defined_envs.each.with_index do |env, i|
+          puts env
 
-          definition = definition_on(env_name)
-          definition.then { _1.themes + _1.plugins }.each do
+          definition_with(env).then { _1.themes + _1.plugins }.each do
             puts "  #{_1.name} (#{Source.from_definition(_1.source).info})"
           end
 
-          puts if i < envs.size - 1
+          puts if i < defined_envs.size - 1
         end
       end
 
@@ -23,15 +22,11 @@ module Rexer
 
       attr_reader :definition
 
-      def defined_envs
-        all_envs = definition.plugins.map(&:env) + definition.themes.map(&:env)
-        all_envs.uniq.sort
-      end
-
-      def definition_on(env)
-        Definition.load_data.tap { |data|
-          data.env = env
-        }
+      def definition_with(env)
+        definition.with(
+          plugins: definition.plugins.select { _1.env == env },
+          themes: definition.themes.select { _1.env == env }
+        )
       end
     end
   end

--- a/lib/rexer/commands/install.rb
+++ b/lib/rexer/commands/install.rb
@@ -37,9 +37,12 @@ module Rexer
       end
 
       def load_definition(env)
-        Definition.load_data.tap { |data|
-          data.env = env
-        }
+        data = Definition.load_data
+        data.with(
+          plugins: data.plugins.select { _1.env == env },
+          themes: data.themes.select { _1.env == env },
+          env:
+        )
       end
 
       def load_lock_definition

--- a/lib/rexer/definition/data.rb
+++ b/lib/rexer/definition/data.rb
@@ -1,22 +1,12 @@
 module Rexer
   module Definition
-    class Data
-      attr_accessor :env
-      attr_reader :version
-
-      def initialize(plugins, themes, env: nil, version: nil)
-        @plugins = plugins
-        @themes = themes
-        @env = env
-        @version = version
+    Data = ::Data.define(:plugins, :themes, :env, :version) do
+      def initialize(plugins:, themes:, env: nil, version: nil)
+        super
       end
 
-      def plugins
-        env ? @plugins.select { _1.env == env } : @plugins
-      end
-
-      def themes
-        env ? @themes.select { _1.env == env } : @themes
+      def envs
+        (plugins.map(&:env) + themes.map(&:env)).uniq.sort
       end
 
       def diff(other)

--- a/lib/rexer/definition/dsl.rb
+++ b/lib/rexer/definition/dsl.rb
@@ -1,10 +1,17 @@
 module Rexer
   module Definition
     class Dsl
-      def initialize(env = :default)
+      def initialize
         @plugins = []
         @themes = []
-        @env = env
+        @env = :default
+      end
+
+      class EnvDsl < self
+        def initialize(env)
+          super()
+          @env = env
+        end
       end
 
       def plugin(name, **opts, &hooks)
@@ -27,7 +34,7 @@ module Rexer
 
       def env(*env_names, &dsl)
         env_names.each do |env_name|
-          data = self.class.new(env_name).tap { _1.instance_eval(&dsl) }.to_data
+          data = EnvDsl.new(env_name).tap { _1.instance_eval(&dsl) }.to_data
 
           @plugins += data.plugins
           @themes += data.themes

--- a/lib/rexer/definition/lock.rb
+++ b/lib/rexer/definition/lock.rb
@@ -23,17 +23,20 @@ module Rexer
 
       class Dsl < Definition::Dsl
         def lock(env:, version:)
-          lock_state.update(env:, version:)
+          @lock_env = env
+          @lock_version = version
         end
 
         def to_data
-          Definition::Data.new(@plugins, @themes, **lock_state)
+          plugins = lock_by_env(@plugins)
+          themes = lock_by_env(@themes)
+          Definition::Data.new(plugins, themes, @lock_env, @lock_version)
         end
 
         private
 
-        def lock_state
-          @lock_state ||= {}
+        def lock_by_env(plugins_or_themes)
+          plugins_or_themes.select { _1.env == @lock_env }
         end
       end
     end

--- a/test/integration/integration_test.rb
+++ b/test/integration/integration_test.rb
@@ -27,7 +27,25 @@ class IntegrationTest < Test::Unit::TestCase
 
     docker_exec("rex envs").then do |result|
       assert_true result.success?
-      assert_equal %w[default env1 env2 env3 env4], result.output
+      assert_equal [
+        "default",
+        "  theme_a (master)",
+        "  plugin_a (master)",
+        "",
+        "env1",
+        "  plugin_a (v0.1.0)",
+        "",
+        "env2",
+        "  theme_a (master)",
+        "  plugin_a (master)",
+        "",
+        "env3",
+        "  theme_a (master)",
+        "  plugin_a (stable)",
+        "",
+        "env4",
+        "  plugin_a (master)"
+      ], result.output
     end
 
     docker_exec("rex install -q").then do |result|


### PR DESCRIPTION
This PR introduces the following enhancement and improves code.

As-is:
```
$ rex envs
default
stable
```

To be like below:
```shell
$ rex envs
default
  bleuclair (master)
  redmine_issue_templates (master)

stable
  redmine_issue_templates (v1.0.0)
```