### PR TITLE
Allow dev command to profile call-stack and benchmark

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,4 @@ gemspec
 gem "rake", "~> 13.0"
 gem "test-unit", "~> 3.0"
 gem "standard", "~> 1.3"
+gem "stackprof"

--- a/README.md
+++ b/README.md
@@ -204,6 +204,25 @@ In the above case, the `bin/rails redmine:plugins:migrate` command is executed a
 
 ## Developing
 
+### Running the command
+
+You can run the command in your local environment without installing the gem as follows.
+
+Setting up the development environment.
+
+```
+$ git clone <this repository>
+$ cd rexer
+$ bundle install
+```
+
+Running the command.
+
+```
+$ cd /path/to/your-local-redmine-source
+$ /your-local-rexer-source/bin/dev state
+```
+
 ### Running tests
 
 First, you need to build the docker image for the integration tests.
@@ -231,6 +250,36 @@ This project uses [Standard](https://github.com/standardrb/standard) for code fo
 ```
 rake standard
 rake standard:fix
+```
+
+### Profiling
+
+Print the call-stack profile.
+
+```
+$ PROFILE=s /your-local-rexer-source/bin/dev state
+...
+
+== Profile ==
+==================================
+  Mode: wall(1000)
+  Samples: 298 (1.97% miss rate)
+  GC: 36 (12.08%)
+==================================
+     TOTAL    (pct)     SAMPLES    (pct)     FRAME
+       261  (87.6%)         147  (49.3%)     Kernel#require
+       ...
+```
+
+Print the benchmark.
+
+```
+$ PROFILE=b /your-local-rexer-source/bin/dev state
+...
+
+== Benchmark ==
+      user     system      total        real
+  0.253115   0.030599   0.283714 (  0.283681)
 ```
 
 ## Contributing

--- a/bin/dev
+++ b/bin/dev
@@ -2,4 +2,39 @@
 
 require_relative "../lib/rexer"
 
-Rexer::Cli.start(ARGV)
+def with_profiling(profile = false)
+  case ENV["PROFILE"]
+
+  # PROFILE=s dev state
+  when "s", "stack"
+    require "stackprof"
+
+    profile = StackProf.run(mode: :wall, interval: 1000) do
+      yield
+    end
+
+    puts
+    puts "== Profile =="
+    StackProf::Report.new(profile).print_text(false, 30)
+
+  # PROFILE=b dev state
+  when "b", "bench"
+    require "benchmark"
+
+    bench = Benchmark.measure do
+      yield
+    end
+
+    puts
+    puts "== Benchmark =="
+    puts Benchmark::CAPTION
+    puts bench
+
+  else
+    yield
+  end
+end
+
+with_profiling(ENV["PROFILE"]) do
+  Rexer::Cli.start(ARGV)
+end


### PR DESCRIPTION
Run with printing call-stack profile:
```
$ PROFILE=stack (or s) /path/to/rexer/bin/dev state
```

Run with printing banchmark:
```
$ PROFILE=banch (or b) /path/to/rexer/bin/dev state
```
