### PR TITLE
Display short SHA references in rex envs and rex state output

### DIFF
--- a/lib/rexer/source/git.rb
+++ b/lib/rexer/source/git.rb
@@ -40,7 +40,7 @@ module Rexer
       end
 
       def reference_name
-        branch || tag || ref || "main"
+        branch || tag || short_ref || "main"
       end
 
       def short_ref

--- a/test/integration/docker/extensions.rb
+++ b/test/integration/docker/extensions.rb
@@ -34,3 +34,10 @@ end
 env :default, :env4 do
   plugin :plugin_a, git: {url: "/git-server-repos/plugin_a.git", ref: "HEAD"}
 end
+
+env :env5 do
+  plugin :plugin_b, git: {
+    url: "/git-server-repos/plugin_b.git",
+    ref: ERB.new("<%= `git -C /git-local-repos/plugin_b rev-parse HEAD`.strip %>").result
+  }
+end

--- a/test/integration/integration_test.rb
+++ b/test/integration/integration_test.rb
@@ -44,7 +44,10 @@ class IntegrationTest < Test::Unit::TestCase
         "  plugin_a (/git-server-repos/plugin_a.git@stable)",
         "",
         "env4",
-        "  plugin_a (/git-server-repos/plugin_a.git@HEAD)"
+        "  plugin_a (/git-server-repos/plugin_a.git@HEAD)",
+        "",
+        "env5",
+        "  plugin_b (/git-server-repos/plugin_b.git@#{plugin_b_head_sha.slice(0, 7)})"
       ], result.output
     end
 
@@ -317,5 +320,9 @@ class IntegrationTest < Test::Unit::TestCase
         " * plugin_a (/git-server-repos/plugin_a.git@master)"
       ], result.output
     end
+  end
+
+  def plugin_b_head_sha
+    docker_exec("git -C /git-local-repos/plugin_b rev-parse HEAD").output_str.strip
   end
 end


### PR DESCRIPTION
Updated `rex envs` and `rex state` commands to show short SHA references (7 characters) when the `ref` option is set.