### PR TITLE
Display real branch name in rex state output

### DIFF
--- a/lib/rexer.rb
+++ b/lib/rexer.rb
@@ -1,12 +1,4 @@
 module Rexer
-  def self.definition_file
-    ".extensions.rb"
-  end
-
-  def self.definition_lock_file
-    ".extensions.lock"
-  end
-
   Config = Data.define(
     # The prefix of the command such as bundle install and bin/rails redmine:plugins:migrate.
     #
@@ -20,6 +12,14 @@ module Rexer
 
   class << self
     attr_accessor :verbosity
+
+    def definition_file
+      ".extensions.rb"
+    end
+
+    def definition_lock_file
+      ".extensions.lock"
+    end
 
     def config
       @config ||= Config.new(command_prefix: ENV["REXER_COMMAND_PREFIX"])

--- a/lib/rexer/commands/envs.rb
+++ b/lib/rexer/commands/envs.rb
@@ -10,8 +10,12 @@ module Rexer
         defined_envs.each.with_index do |env, i|
           puts env
 
-          definition_with(env).then { _1.themes + _1.plugins }.each do
-            puts "  #{_1.name} (#{Source.from_definition(_1.source).info})"
+          themes_in(env) do
+            print_extension_definition(_1)
+          end
+
+          plugins_in(env) do
+            print_extension_definition(_1)
           end
 
           puts if i < defined_envs.size - 1
@@ -22,11 +26,20 @@ module Rexer
 
       attr_reader :definition
 
-      def definition_with(env)
-        definition.with(
-          plugins: definition.plugins.select { _1.env == env },
-          themes: definition.themes.select { _1.env == env }
-        )
+      def print_extension_definition(extension_def)
+        puts "  #{extension_def.name} (#{Source.from_definition(extension_def.source).info})"
+      end
+
+      def themes_in(env)
+        definition.themes.each do
+          yield _1 if _1.env == env
+        end
+      end
+
+      def plugins_in(env)
+        definition.plugins.each do
+          yield _1 if _1.env == env
+        end
       end
     end
   end

--- a/lib/rexer/commands/state.rb
+++ b/lib/rexer/commands/state.rb
@@ -20,27 +20,25 @@ module Rexer
       attr_reader :lock_definition
 
       def print_plugins
-        plugins = lock_definition.plugins
-        return if plugins.empty?
+        plugin_defs = lock_definition.plugins
+        return if plugin_defs.empty?
 
         puts "\nPlugins:"
-        plugins.each do
-          puts " * #{_1.name} (#{source_info(_1.source)})"
+        plugin_defs.each do
+          plugin = Extension::Entity::Plugin.new(_1)
+          puts " * #{plugin.name} (#{plugin.source_info})"
         end
       end
 
       def print_themes
-        themes = lock_definition.themes
-        return if themes.empty?
+        theme_defs = lock_definition.themes
+        return if theme_defs.empty?
 
         puts "\nThemes:"
-        themes.each do
-          puts " * #{_1.name} (#{source_info(_1.source)})"
+        theme_defs.each do
+          theme = Extension::Entity::Theme.new(_1)
+          puts " * #{theme.name} (#{theme.source_info})"
         end
-      end
-
-      def source_info(definition_source)
-        Source.from_definition(definition_source).info
       end
 
       def no_lock_file_found

--- a/lib/rexer/extension/entity.rb
+++ b/lib/rexer/extension/entity.rb
@@ -1,0 +1,55 @@
+require "active_support/core_ext/class/attribute"
+
+module Rexer
+  module Extension
+    module Entity
+      class Base
+        class_attribute :root_dir
+
+        def initialize(definition)
+          @definition = definition
+          @hooks = definition.hooks || {}
+          @name = definition.name
+        end
+
+        attr_reader :hooks, :name
+
+        def exist?
+          path.exist? && !path.empty?
+        end
+
+        def path
+          @path ||= root_dir.join(name.to_s)
+        end
+
+        def source_info
+          @source_info ||= source.info(path)
+        end
+
+        def source
+          @source ||= Source.from_definition(definition.source)
+        end
+
+        private
+
+        attr_reader :definition
+      end
+
+      class Plugin < Base
+        self.root_dir = Pathname.new("plugins")
+
+        def contains_db_migrations?
+          path.join("db", "migrate").then { _1.exist? && !_1.empty? }
+        end
+
+        def contains_gemfile?
+          path.join("Gemfile").exist?
+        end
+      end
+
+      class Theme < Base
+        self.root_dir = Pathname.new("themes")
+      end
+    end
+  end
+end

--- a/lib/rexer/extension/plugin/reload_source.rb
+++ b/lib/rexer/extension/plugin/reload_source.rb
@@ -3,9 +3,9 @@ module Rexer
     module Plugin
       class ReloadSource < Action
         def call
-          return unless plugin_exists?
+          return unless plugin.exist?
 
-          broadcast(:started, "Reload #{name} source")
+          broadcast(:started, "Reload #{plugin.name} source")
 
           reload_source
           run_db_migrate
@@ -16,10 +16,8 @@ module Rexer
         private
 
         def reload_source
-          plugin_dir.to_s.then { |dir|
-            FileUtils.rm_rf(dir)
-            source.load(dir)
-          }
+          plugin.path.rmtree
+          plugin.source.load(plugin.path.to_s)
         end
       end
     end

--- a/lib/rexer/extension/plugin/uninstall.rb
+++ b/lib/rexer/extension/plugin/uninstall.rb
@@ -3,16 +3,16 @@ module Rexer
     module Plugin
       class Uninstall < Action
         def call
-          broadcast(:started, "Uninstall #{name}")
+          broadcast(:started, "Uninstall #{plugin.name}")
 
-          unless plugin_exists?
+          unless plugin.exist?
             broadcast(:skipped, "Not exists")
             return
           end
 
           reset_db_migration
           remove_plugin
-          hooks[:uninstalled]&.call
+          call_uninstalled_hook
 
           broadcast(:completed)
         end
@@ -24,7 +24,11 @@ module Rexer
         end
 
         def remove_plugin
-          plugin_dir.rmtree
+          plugin.path.rmtree
+        end
+
+        def call_uninstalled_hook
+          plugin.hooks[:uninstalled]&.call
         end
       end
     end

--- a/lib/rexer/extension/plugin/update.rb
+++ b/lib/rexer/extension/plugin/update.rb
@@ -3,11 +3,11 @@ module Rexer
     module Plugin
       class Update < Action
         def call
-          return unless plugin_exists?
+          return unless plugin.exist?
 
-          broadcast(:started, "Update #{name}")
+          broadcast(:started, "Update #{plugin.name}")
 
-          unless source.updatable?
+          unless plugin.source.updatable?
             broadcast(:skipped, "Not updatable")
             return
           end
@@ -21,7 +21,7 @@ module Rexer
         private
 
         def update_source
-          source.update(plugin_dir.to_s)
+          plugin.source.update(plugin.path)
         end
       end
     end

--- a/lib/rexer/extension/theme/action.rb
+++ b/lib/rexer/extension/theme/action.rb
@@ -8,36 +8,12 @@ module Rexer
 
         def initialize(definition)
           @definition = definition
-          @name = definition.name
-          @hooks = definition.hooks || {}
+          @theme = Entity::Theme.new(definition)
         end
 
         private
 
-        attr_reader :name, :hooks, :definition
-
-        def theme_root_dir
-          public_themes = Pathname.pwd.join("public", "themes")
-
-          if public_themes.exist?
-            # When Redmine version is v5.1 or older, public/themes is used.
-            public_themes
-          else
-            Pathname.new("themes")
-          end
-        end
-
-        def theme_dir
-          @theme_dir ||= theme_root_dir.join(name.to_s)
-        end
-
-        def theme_exists?
-          theme_dir.exist? && !theme_dir.empty?
-        end
-
-        def source
-          @source ||= Source.from_definition(definition.source)
-        end
+        attr_reader :theme
       end
     end
   end

--- a/lib/rexer/extension/theme/install.rb
+++ b/lib/rexer/extension/theme/install.rb
@@ -3,15 +3,15 @@ module Rexer
     module Theme
       class Install < Action
         def call
-          broadcast(:started, "Install #{name}")
+          broadcast(:started, "Install #{theme.name}")
 
-          if theme_exists?
+          if theme.exist?
             broadcast(:skipped, "Already exists")
             return
           end
 
           load_from_source
-          hooks[:installed]&.call
+          call_installed_hook
 
           broadcast(:completed)
         end
@@ -19,7 +19,11 @@ module Rexer
         private
 
         def load_from_source
-          source.load(theme_dir.to_s)
+          theme.source.load(theme.path.to_s)
+        end
+
+        def call_installed_hook
+          theme.hooks[:installed]&.call
         end
       end
     end

--- a/lib/rexer/extension/theme/reload_source.rb
+++ b/lib/rexer/extension/theme/reload_source.rb
@@ -3,9 +3,9 @@ module Rexer
     module Theme
       class ReloadSource < Action
         def call
-          return unless theme_exists?
+          return unless theme.exist?
 
-          broadcast(:started, "Reload #{name} source")
+          broadcast(:started, "Reload #{theme.name} source")
 
           reload_source
 
@@ -15,10 +15,8 @@ module Rexer
         private
 
         def reload_source
-          theme_dir.to_s.then { |dir|
-            FileUtils.rm_rf(dir)
-            source.load(dir)
-          }
+          theme.path.rmtree
+          theme.source.load(theme.path.to_s)
         end
       end
     end

--- a/lib/rexer/extension/theme/uninstall.rb
+++ b/lib/rexer/extension/theme/uninstall.rb
@@ -3,15 +3,15 @@ module Rexer
     module Theme
       class Uninstall < Action
         def call
-          broadcast(:started, "Uninstall #{name}")
+          broadcast(:started, "Uninstall #{theme.name}")
 
-          unless theme_exists?
+          unless theme.exist?
             broadcast(:skipped, "Not exists")
             return
           end
 
           remove_theme
-          hooks[:uninstalled]&.call
+          call_uninstalled_hook
 
           broadcast(:completed)
         end
@@ -19,7 +19,11 @@ module Rexer
         private
 
         def remove_theme
-          theme_dir.rmtree
+          theme.path.rmtree
+        end
+
+        def call_uninstalled_hook
+          theme.hooks[:uninstalled]&.call
         end
       end
     end

--- a/lib/rexer/extension/theme/update.rb
+++ b/lib/rexer/extension/theme/update.rb
@@ -3,9 +3,9 @@ module Rexer
     module Theme
       class Update < Action
         def call
-          return unless theme_exists?
+          return unless theme.exist?
 
-          broadcast(:started, "Update #{name}")
+          broadcast(:started, "Update #{theme.name}")
 
           update_source
 
@@ -15,7 +15,7 @@ module Rexer
         private
 
         def update_source
-          source.update(theme_dir.to_s)
+          theme.source.update(theme.path.to_s)
         end
       end
     end

--- a/lib/rexer/source/base.rb
+++ b/lib/rexer/source/base.rb
@@ -17,7 +17,7 @@ module Rexer
       end
 
       # Return the status of the source.
-      def info = ""
+      def info(_work_dir = nil) = ""
     end
   end
 end

--- a/lib/rexer/source/github.rb
+++ b/lib/rexer/source/github.rb
@@ -6,8 +6,8 @@ module Rexer
         super(url: "https://github.com/#{repo}", branch: branch, tag: tag, ref: ref)
       end
 
-      def info
-        "#{@repo}@#{reference_name}"
+      def info(work_dir = nil)
+        [@repo, reference(short_ref: true) || current_branch(work_dir)].compact.join("@")
       end
     end
   end

--- a/test/integration/integration_test.rb
+++ b/test/integration/integration_test.rb
@@ -29,7 +29,7 @@ class IntegrationTest < Test::Unit::TestCase
       assert_true result.success?
       assert_equal [
         "default",
-        "  theme_a (/git-server-repos/theme_a.git@main)",
+        "  theme_a (/git-server-repos/theme_a.git)",
         "  plugin_a (/git-server-repos/plugin_a.git@HEAD)",
         "",
         "env1",
@@ -40,7 +40,7 @@ class IntegrationTest < Test::Unit::TestCase
         "  plugin_a (/git-server-repos/plugin_a.git@master)",
         "",
         "env3",
-        "  theme_a (/git-server-repos/theme_a.git@main)",
+        "  theme_a (/git-server-repos/theme_a.git)",
         "  plugin_a (/git-server-repos/plugin_a.git@stable)",
         "",
         "env4",
@@ -58,7 +58,7 @@ class IntegrationTest < Test::Unit::TestCase
         "Env: default",
         "",
         "Themes:",
-        " * theme_a (/git-server-repos/theme_a.git@main)",
+        " * theme_a (/git-server-repos/theme_a.git@master)",
         "",
         "Plugins:",
         " * plugin_a (/git-server-repos/plugin_a.git@HEAD)"
@@ -222,7 +222,7 @@ class IntegrationTest < Test::Unit::TestCase
         "Env: default",
         "",
         "Plugins:",
-        " * plugin_a (/git-server-repos/plugin_a.git@main)"
+        " * plugin_a (/git-server-repos/plugin_a.git@master)"
       ], result.output
     end
 
@@ -235,8 +235,8 @@ class IntegrationTest < Test::Unit::TestCase
         "Env: default",
         "",
         "Plugins:",
-        " * plugin_a (/git-server-repos/plugin_a.git@main)",
-        " * plugin_b (/git-server-repos/plugin_b.git@main)"
+        " * plugin_a (/git-server-repos/plugin_a.git@master)",
+        " * plugin_b (/git-server-repos/plugin_b.git@master)"
       ], result.output
     end
 
@@ -250,7 +250,7 @@ class IntegrationTest < Test::Unit::TestCase
         "",
         "Plugins:",
         " * plugin_a (/git-server-repos/plugin_a.git@v0.1.0)",
-        " * plugin_b (/git-server-repos/plugin_b.git@main)"
+        " * plugin_b (/git-server-repos/plugin_b.git@master)"
       ], result.output
     end
 
@@ -263,7 +263,7 @@ class IntegrationTest < Test::Unit::TestCase
         "Env: default",
         "",
         "Plugins:",
-        " * plugin_a (/git-server-repos/plugin_a.git@main)"
+        " * plugin_a (/git-server-repos/plugin_a.git@master)"
       ], result.output
     end
   end


### PR DESCRIPTION
For example, redmica/redmine_issues_panel's default branch is "default-branch-name".
```
$ git -C plugins/redmine_issues_panel branch --show-current
default-branch-name
```

`.extensions.rb` does not contain branch option for redmine_issues_panel plugin.
```
...
plugin :redmine_issues_panel, github: { repo: "redmica/redmine_issues_panel" }
...
```

v0.14.1 always displays "main" as default branch name:
```
$ rex state
Rexer: 0.14.1
Env: default

Plugins:
 * redmine_issues_panel (redmica/redmine_issues_panel@main)
```

This PR always displays current branch name:
```
$ rex state
Rexer: 0.14.1
Env: default

Plugins:
 * redmine_issues_panel (redmica/redmine_issues_panel@feature-branch)
```